### PR TITLE
Python3 compat fix for _ph.py

### DIFF
--- a/ete3/_ph.py
+++ b/ete3/_ph.py
@@ -66,7 +66,7 @@ def call():
     try:
         f = urlopen('http://etetoolkit.org/static/et_phone_home.php?VERSION=%s&ID=%s'
                 %(__version__, __ETEID__))
-    except Exception, e:
+    except:
         print("No answer :(")
     else:
         print("Got answer!")


### PR DESCRIPTION
Noticed a syntax error on pip install:

```
$ pip3 install ete3==3.0.0b33
<<<SNIP>>>
    Installing ete3 script to ~/.local/bin
      File "~/.local/lib/python3.5/site-packages/ete3/_ph.py", line 69
        except Exception, e:
                        ^
    SyntaxError: invalid syntax

     - Done! -
Successfully installed ete3
Cleaning up...
```
